### PR TITLE
Change logic flow to accommodate iPad/iPhone

### DIFF
--- a/print_elements.js
+++ b/print_elements.js
@@ -59,17 +59,37 @@ var PrintElements = (function () {
         }
     };
 
+    var _delayedCleanup = function (elements) {
+      for (var i = 0; i < elements.length; i++) {
+          _walkTree(elements[i], _cleanup);
+      }
+    }
+
+    var _cleanAll = function() {
+      const elements = document.querySelector(bodyElementName).querySelectorAll('*');
+      for ( var currentElement of elements ) {
+        if( currentElement && currentElement.nodeName !== bodyElementName ) {
+            _clean( currentElement );
+        }
+      }
+    }
+
     var _print = function (elements) {
+        _cleanAll();
         for (var i = 0; i < elements.length; i++) {
             _walkTree(elements[i], _attachPrintClasses);
         }
+        // The iPad does not pause on window.print() so we can not do cleanup right
+        // after that call. Below are two attempts to delay this callback to avoid this,
+        // but on iPad neither of these proved satisfactory, created a _cleanAll that is
+        // called before a new print is set up or could be called externally
+        // window.addEventListener('afterprint', function() { _delayedCleanup(elements) } );
+        // setTimeout( function() { _delayedCleanup(elements) }, 10000 );
         window.print();
-        for (i = 0; i < elements.length; i++) {
-            _walkTree(elements[i], _cleanup);
-        }
     };
 
     return {
-        print: _print
+        print: _print,
+        cleanAll: _cleanAll
     };
 })();


### PR DESCRIPTION
The iPad does not pause on window.print() so we can not do cleanup right after that call. Change logic flow to accommodate it.